### PR TITLE
feat(security): Add AES-CBC with XXTEA fallback for compatibility

### DIFF
--- a/adminer/include/aes-cbc.inc.php
+++ b/adminer/include/aes-cbc.inc.php
@@ -1,0 +1,75 @@
+<?php
+
+
+/**
+ * Generates a secure IV compatible with PHP 5 and PHP 7+.
+ *
+ * @param int $length IV length.
+ * @return string Generated IV.
+ */
+function generate_iv($length)
+{
+    if (function_exists('random_bytes')) {
+        return random_bytes($length);
+    }
+    // Fallback for older versions
+    return openssl_random_pseudo_bytes($length);
+}
+
+/**
+ * Encrypts a string using AES-256-CBC.
+ *
+ * @param  string $plaintext Plain text to encrypt.
+ * @param  string $key       Encryption key.
+ * @return string Base64-encoded encrypted text.
+ */
+function encrypt_string($plaintext, $key)
+{
+    // Generates a 256-bit (32-byte) key from the SHA-512 hash.
+    $key = substr(hash('sha512', $key, true), 0, 32);
+    // Generates a secure 16-byte IV.
+    $iv = generate_iv(16);
+    // Encrypts the text using AES-256-CBC.
+    $ciphertext = openssl_encrypt($plaintext, 'aes-256-cbc', $key, OPENSSL_RAW_DATA, $iv);
+    if ($ciphertext === false) {
+        return false;
+    }
+    // Generates an HMAC using IV + ciphertext to ensure integrity.
+    $hmac = hash_hmac('sha512', $iv . $ciphertext, $key, true);
+    // Encodes in base64: IV + HMAC + ciphertext.
+    return base64_encode($iv . $hmac . $ciphertext);
+}
+
+/**
+ * Decrypts an AES-256-CBC encrypted string.
+ *
+ * @param  string $ciphertext_base64 Base64-encoded encrypted text.
+ * @param  string $key               Decryption key.
+ * @return string|false Plain text or false if authentication fails.
+ */
+function decrypt_string($ciphertext_base64, $key)
+{
+    // Generates a 256-bit (32-byte) key from the SHA-512 hash.
+    $key = substr(hash('sha512', $key, true), 0, 32);
+    // Decodes the base64 string.
+    $data = base64_decode($ciphertext_base64);
+    // IV (16) + HMAC (64) minimum
+    if ($data === false || strlen($data) < 80) {
+        return false;
+    }
+    // Extracts IV (16 bytes), HMAC (64 bytes), and encrypted text.
+    $iv = substr($data, 0, 16);
+    $hmac = substr($data, 16, 64);
+    $ciphertext = substr($data, 80);
+    if ($iv === false || $hmac === false || $ciphertext === false) {
+        return false;
+    }
+    // Verifies integrity using HMAC-SHA512.
+    $calculated_hmac = hash_hmac('sha512', $iv . $ciphertext, $key, true);
+    // Protection against timing attacks.
+    if (!hash_equals($hmac, $calculated_hmac)) {
+        return false;
+    }
+    // Decrypts the text.
+    return openssl_decrypt($ciphertext, 'aes-256-cbc', $key, OPENSSL_RAW_DATA, $iv);
+}

--- a/adminer/include/bootstrap.inc.php
+++ b/adminer/include/bootstrap.inc.php
@@ -151,7 +151,12 @@ define("HOME_URL", substr(preg_replace('~\b(username|db|ns)=[^&]*&~', '', ME), 0
 
 include "../adminer/include/version.inc.php";
 include "../adminer/include/design.inc.php";
-include "../adminer/include/xxtea.inc.php";
+
+if (extension_loaded('openssl')) {
+    include "../adminer/include/aes-cbc.inc.php";
+} else {
+    include "../adminer/include/xxtea.inc.php";
+}
 include "../adminer/include/auth.inc.php";
 include "./include/editing.inc.php";
 include "./include/connect.inc.php";


### PR DESCRIPTION
Implement AES-CBC encryption for improved security and data integrity.
Ensure authenticated encryption with a secure key and random IV.
Maintain compatibility with PHP 5.6 by keeping XXTEA as a fallback.
Dynamically select encryption method based on OpenSSL availability.
Refactor bootstrap.inc.php to conditionally include the appropriate encryption module.