### PR TITLE
fix for entered SQL when $history is NULL

### DIFF
--- a/adminer/sql.inc.php
+++ b/adminer/sql.inc.php
@@ -44,7 +44,7 @@ if (!$error && $_POST) {
 
 		if ($query != "" && strlen($query) < 1e6) { // don't add big queries
 			$q = $query . (preg_match("~;[ \t\r\n]*\$~", $query) ? "" : ";"); //! doesn't work with DELIMITER |
-			$last_record = end($history);
+			$last_record = $history ? end($history) : $last_record = [];
 			if (!$history || ($last_record && reset($last_record) != $q)) { // no repeated queries
 				restart_session();
 				$history[] = array($q, time()); //! add elapsed time


### PR DESCRIPTION
## Description
When the SQL `$history` is clear, and SQL is entered, the following error is visible in a PHP **E_ALL** environment.
![adminneo](https://github.com/user-attachments/assets/2828ad8b-af6d-42bd-bfa9-b9190f1ffa60)
## Steps To Reproduce
1. Log all the way out of AdminNeo (so that  SQL `$history` is clear)
2. Log in to AdminNeo and select any database
3. Click **_"SQL Command"_** from the upper left, and enter any SQL (`SELECT * FROM table`)
## Additional Context
This bug appears to have been introduced in 1f133eb459490300e3c7231b3663e46453d487cd where `$history` is fed to `end()` to set `$last_record` (and can be NULL if `$history` is clear).

This PR simply adds conditional logic to see if `$history` is NULL, and if so, set `$last_record` to an empty array (which is then harmlessly fed to `reset()` on the next line).

@peterpp This PR is for `main` but this same bug is present in `version-5`.