### PR TITLE
V5: fix compiled favicons

### DIFF
--- a/bin/compile.php
+++ b/bin/compile.php
@@ -576,11 +576,11 @@ for ($i = 0; $i < count($matches[0]); $i++) {
 	}
 
 	// Favicons.
-	if (str_contains($name, 'icon-$color_variant.')) {
+	if (str_contains($name, 'icon-$colorVariant.')) {
 		foreach ($selected_themes as $theme) {
 			if (preg_match('~^default-(blue|green|red)$~', $theme, $matches2)) {
-				$name2 = str_replace('$color_variant', $matches2[1], $name);
-				$files2 = str_replace('$color_variant', $matches2[1], $files);
+				$name2 = str_replace('$colorVariant', $matches2[1], $name);
+				$files2 = str_replace('$colorVariant', $matches2[1], $files);
 
 				append_linked_files_cases($name2, $files2, $name_cases, $data_cases);
 			}


### PR DESCRIPTION
This fixes V5 compile to include the proper theme/color **favicons**.

@peterpp Looking around the code base, there may be some additional fallout from the interchange of `$color_variant` and `$colorVariant`. For example this compile works as expected:

`php bin/compile.php mysql en default`

But this results in a compilation with missing CSS:

`php bin/compile.php mysql en default-red`

This again appears to be related to `$color_variant` vs `$colorVariant`.