### PR TITLE
Auto-create log folder structure

### DIFF
--- a/plugins/SqlLogPlugin.php
+++ b/plugins/SqlLogPlugin.php
@@ -46,6 +46,12 @@ class SqlLogPlugin extends Plugin
 			$this->filename = $dbName . ($dbName ? "-" : "") . "log.sql";
 		}
 
+		$folder = dirname($this->filename);
+
+		if (!is_dir($folder)) {
+			mkdir($folder, 0777, true); // create folder struct recursively if it doesnt exist
+		}
+
 		$fp = fopen($this->filename, "a");
 
 		flock($fp, LOCK_EX);


### PR DESCRIPTION
This PR makes the SqlLog plugin to create the folder structure, if it does not exist (and if there are permissions).

Useful for i.e. having the logs separated by folder:

```
new \AdminNeo\SqlLogPlugin(__DIR__ . '/logs/' . date("Y/m/d/H") . ".txt"),
```